### PR TITLE
Don't send endless newlines on EOF

### DIFF
--- a/echo.rb
+++ b/echo.rb
@@ -3,8 +3,7 @@ require 'socket'
 server = TCPServer.new 7
 loop do
   Thread.start(server.accept) do |client|
-    while true
-     msg = client.gets
+    while msg = client.gets
      client.puts msg
     end    
   end


### PR DESCRIPTION
The title is pretty self-explanatory. Since the spec says the connection should be closed by the client, I chose to not close the connection in case of EOF.

To verify this behaviour, press Ctrl-D (EOT) when using netcat.
